### PR TITLE
create interim steering council

### DIFF
--- a/steering_council_membership.md
+++ b/steering_council_membership.md
@@ -6,4 +6,4 @@ The initial interim steering council of Pangeo consists of:
 - Ryan Abernathey
 - Kevin Paul
 
-This steering council is expected to be replaced by a non-interim steering council after a nomination and discussion period.
+This steering council is expected to be replaced by a non-interim steering council after a nomination and discussion period, no later than Nov. 15, 2018.

--- a/steering_council_membership.md
+++ b/steering_council_membership.md
@@ -1,0 +1,9 @@
+# Steering Council Membership
+
+## Interim Steering Council (2018-10-10)
+
+The initial interim steering council of Pangeo consists of:
+- Ryan Abernathey
+- Kevin Paul
+
+This steering council is expected to be replaced by a non-interim steering council after a nomination and discussion period.


### PR DESCRIPTION
As discussed in https://github.com/pangeo-data/governance/issues/8#issuecomment-425242003, this will create an initial interim steering council consisting of myself and @kmpaul. 

Next steps after this:
- this temporary council approves and merges the governance plan (#10), which has hopefully reached a consensus
- the temporary council oversees a nomination process and appointment of a non-temporary steering council (as defined in the governance document), taking into account all the many issues regarding participation, diversity, inclusion, and representation that have been raised in this discussion. We hope to achieve a consensus on the non-temporary steering council. If not, the temporary steering council does their best to make a wise executive decision in selecting a non-temporary steering council.