### PR TITLE
Integration of Mission Statement, edits to Contributors description

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -8,12 +8,18 @@ https://github.com/pangeo-data/governance
 
 ## The Project
 
-The Pangeo Project (The Project) is an open source software project. The goal 
-of The Project is to develop open source software and related technology for the 
-analysis of large scientific datasets. The Project endeavors to extend the 
-broader scientific software ecosystem.  The Software developed by The Project is
-released under the BSD (or similar) open source license, developed openly and 
-hosted in public GitHub repositories under the Pangeo-data GitHub organization.
+The Pangeo Project (The Project) is first and foremost a community of people
+working collaboratively to develop software and infrastructure to enable Big Data
+geoscience research. Our mission is to cultivate an ecosystem in which the next
+generation of open-source analysis tools for ocean, atmosphere and climate science
+can be developed, distributed, and sustained. These tools must be scalable in
+order to meet the current and future challenges of big data, and these solutions
+should leverage the existing expertise outside of the geoscience community.
+
+The Project endeavors to extend the broader scientific software ecosystem. 
+The Software developed by The Project is released under the BSD (or similar) open
+source license, developed openly and hosted in public GitHub repositories under the
+Pangeo-data GitHub organization.
 Examples of Project Software include the tools and configurations related to the
 deployment of computational infrastructure. The Services run by The Project
 consist of public websites and web-services that are hosted under the pangeo.io
@@ -22,18 +28,20 @@ website (https://pangeo-data.org and https://pangeo.io), Pangeo-JupyterHub
 deployments (https://pangeo.pydata.org and https://pangeo.informaticslab.co.uk),
 and the Pangeo-Binder (https://binder.pangeo.io).
 
-The Project is developed by a team of distributed developers, called
+
+## Contributors
+
+The Project is maintained by a distributed team of people, called
 Contributors. Contributors are individuals who have contributed to code, code
-reviews, documentation, design, and infrastructure, or to mailing lists, chats,
+reviews, documentation, design, infrastructure, mailing lists, chats,
 community help and community building, education and outreach, or other work in
 relation to one or more Project repositories. Anyone can be a Contributor.
-Contributors can be affiliated with any legal entity or none. Contributors
-participate in The Project by submitting, reviewing and discussing GitHub Pull
-Requests and Issues and participating in open and public Project discussions on
-GitHub, Gitter chat rooms and mailing lists. The foundation of Project
-participation is openness and transparency.
+Contributors can be affiliated with any legal entity or none. The foundation of
+Project participation is openness and transparency.
 
-Here is a list of the current Contributors to the main Pangeo repository:
+While community building can be more difficult to track, edits to documentation
+and code are logged by Github. Here is a list of the current Contributors to
+the main Pangeo repository:
 
 https://github.com/pangeo-data/pangeo/graphs/contributors
 


### PR DESCRIPTION
* Modified head of The Project section to pull directly from the mission
  statement and https://pangeo.io/about.html, as per #23 
* Separated section on Contributors
* Modified Contributors section to put non-code contributions on more
  equal footing to code contributions (e.g. by not referring to
  Contributors as developers).