### PR TITLE
add email and web forms for reporting conduct violations

### DIFF
--- a/conduct/code_of_conduct.md
+++ b/conduct/code_of_conduct.md
@@ -84,7 +84,7 @@ make it easier to enrich all of us and the communities in which we participate.
 By embracing the following principles, guidelines and actions to follow or
 avoid, you will help us make Pangeo a welcoming and productive community. Feel
 free to contact the Code of Conduct Committee at
-[*TODO*](mailto:TODO) with any questions.
+[pangeo-conduct@googlegroups.com](mailto:pangeo-conduct@googlegroups.com) with any questions.
 
 
 ## Forms of harrassment
@@ -111,7 +111,7 @@ Forms of harrassment include, but is not limited to:
 
 If a member of the community at large engages in behavior which is harassing 
 or discriminatory in any way, once the incident is reported, 
-the [Code of Conduct Committee](mailto:TODO) may take any action they deem 
+the [Code of Conduct Committee](mailto:pangeo-conduct@googlegroups.com) may take any action they deem 
 appropriate listed in the [*Enforcement Manual*](enforcement.md). 
 These actions include, but are not limited to, issuing a warning, 
 requiring an apology, or a permanent or temporary ban from some 
@@ -125,10 +125,10 @@ a timely manner. Code of conduct violations reduce the value of the community
 for everyone and we take them seriously.
 
 You can file a report by emailing
-[*TODO*](mailto:TODO) or by filing out 
-[this form](TODO). The online form gives you the option to keep your report anonymous or request
-that we follow up with you directly. While we cannot follow up on an anonymous
-report, we will take appropriate action.
+[pangeo-conduct@googlegroups.com](mailto:pangeo-conduct@googlegroups.com) or by filing out 
+[this form](https://forms.gle/jDmUokAtzwxwkKQq7). The online form gives you the option to 
+keep your report anonymous or request that we follow up with you directly. While we cannot
+follow up on an anonymous report, we will take appropriate action.
 
 For more details or information on reporting in-person at an event, please see our Reporting
 Guidelines.   
@@ -143,7 +143,7 @@ As such, the Pangeo Steering Council commits to an annual review
 of the Code of Conduct to ensure that it continues to align with 
 this goal and address the needs of our community.
 Pangeo welcomes feedback from its members. 
-Feedback can be submitted to: [*TODO*](mailto:TODO) and to this github repository.
+Feedback can be submitted to: [pangeo-conduct@googlegroups.com](mailto:pangeo-conduct@googlegroups.com) and to this github repository.
 
 
 ### References

--- a/conduct/reporting_events.md
+++ b/conduct/reporting_events.md
@@ -13,10 +13,9 @@ overheard. They may involve other event staff to ensure your report is managed
 properly. This can be uncomfortable, but we'll handle it respectfully and you
 can bring someone to support you.
 
-**Email**: Send a message to
-[*TODO*](mailto:TODO) and/or a local organizer’s
-email (best to do both to ensure both prompt local response and that the
-regular committee is immediately in the loop).
+**Email**: Send a message to [pangeo-conduct@googlegroups.com](mailto:pangeo-conduct@googlegroups.com)
+and/or a local organizer’s email (best to do both to ensure both prompt local
+response and that the regular committee is immediately in the loop).
 
 Our team will help you contact hotel/venue security, local law enforcement,
 local support (which could include services and transportation as available), or
@@ -24,8 +23,8 @@ otherwise respectfully assist you to feel safe for the duration of the event.
 
 Contact information for the following will be provided per event:
 
-* Email: [*TODO*](mailto:TODO), and/or a local
-  organizer
+* Email: [pangeo-conduct@googlegroups.com](mailto:pangeo-conduct@googlegroups.com),
+  and/or a local organizer
 * Conference organizer mobile number
 * Venue security
 * Law enforcement
@@ -46,5 +45,5 @@ Contact information for the following will be provided per event:
   hostile for any participants.
 
 You also have the option of following the reporting procedure for the online
-community found [here](TODO). Just be aware
+community found [here](reporting_online.md). Just be aware
 the response and action may not be as prompt.

--- a/conduct/reporting_online.md
+++ b/conduct/reporting_online.md
@@ -1,11 +1,10 @@
 # Pangeo Code of Conduct - Reporting Guide - Online Community
 
 If you believe someone is violating the code of conduct we ask that you report
-it to Pangeo by emailing
-[*TODO*](mailto:TODO) or by completing [this
-form](TODO). All reports will be kept
-confidential. In some cases we may determine that a public statement will need
-to be made. If that's the case, the identities of all involved will remain
+it to Pangeo by emailing [pangeo-conduct@googlegroups.com](mailto:pangeo-conduct@googlegroups.com)
+or by completing [this form](https://forms.gle/jDmUokAtzwxwkKQq7). All reports
+will be kept confidential. In some cases we may determine that a public statement
+will need to be made. If that's the case, the identities of all involved will remain
 confidential unless those individuals instruct us otherwise.
 
 If you believe anyone is in physical danger, please notify appropriate law
@@ -57,9 +56,8 @@ communicate a resolution.
 ## Appealing the Code of Conduct Committee’s Response
 
 To appeal a decision of the Code of Conduct Committee, contact the Pangeo
-Steering Council at
-[*TODO*](mailto:TODO) with your
-appeal and they will review the case.
+Steering Council at [pangeo-steering-council@googlegroups.com](mailto:pangeo-steering-council@googlegroups.com)
+with your appeal and they will review the case.
 
 The Steering Council will gather all relevant information from the Committee
 and provide a resolution within two weeks.  If more time is required, it should


### PR DESCRIPTION
Ahead of this summer's community meeting, I thought we should finish up the conduct reporting TODO's in our code of conduct. For now, I will be adding the @pangeo-data/steering-council  to the recipients of any reports.

I would like to merge this by CoB tomorrow (Aug. 20, 2019). 

Links are here:

- conduct committee email: pangeo-conduct@googlegroups.com
- steering-council email: pangeo-steering-council@googlegroups.com
- google form for reporting: https://forms.gle/jDmUokAtzwxwkKQq7