### PR TITLE
Define duration of contribution for Institutional Contributor 

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -153,9 +153,9 @@ institutional participation in The Project. These are Institutional Partners.
 
 An Institutional Contributor is any individual Project Contributor who
 contributes to The Project as part of their official duties at an Institutional
-Partner. Likewise, an Institutional Council Member is any Project Steering
-Council Member who contributes to The Project as part of their official duties
-at an Institutional Partner.
+Partner sustained over at least six months. Likewise, an Institutional Council
+Member is any Project Steering Council Member who contributes to The Project as
+part of their official duties at an Institutional Partner.
 
 With these definitions, an Institutional Partner is any recognized legal entity
 anywhere in the world that employs at least one Institutional Contributor or


### PR DESCRIPTION
The topic of Institutional Partners and Contributors came up in our recent Steering Council meeting. In particular, we noticed that our current governance documents do not specify what duration of time an individual would need to contribute to the Project to qualify as an Institutional Contributor (and thereby qualifying the host institution to be an Institutional Partner). This edit propose a six month duration of sustained contribution and leaves in place the one-year grace period should an Institutional Partner have a window without an active contributor. 

cc @pangeo-data/steering-council, @pangeo-data/pangeo-members 