### PR TITLE
Add Guillaume Eynard-Bontemps to Steering Council

### DIFF
--- a/steering_council_membership.md
+++ b/steering_council_membership.md
@@ -11,3 +11,4 @@ The Pangeo steering council members are:
 - Niall Robinson (@niallrobinson)
 - Rich Signell (@rsignell-usgs)
 - Amanda Tan (@amanda-tan)
+- Guillaume Eynard-Bontemps (@guillaumeeb)


### PR DESCRIPTION
I'm please to announce that we are adding @guillaumeeb to the Pangeo Project's Steering Council. Guillaume is a distributed software engineer at the French space agency (CNES). He has been an active contributor to a number of Dask projects including dask-distributed and dask-jobqueue. He has also made contributions across the Pangeo Project in the form of improvements to our documentation and hosting the European Pangeo meeting this year. I had the pleasure of nominating @guillaumeeb and he was confirmed unanimously by the existing members of the steering council. 