### PR TITLE
Add Chelle Gentemann to steering council

### DIFF
--- a/steering_council_membership.md
+++ b/steering_council_membership.md
@@ -1,7 +1,5 @@
 # Steering Council Membership
 
-## 2018-11-27
-
 The Pangeo steering council members are:
 
 - Ryan Abernathey (@rabernat)
@@ -12,3 +10,4 @@ The Pangeo steering council members are:
 - Rich Signell (@rsignell-usgs)
 - Amanda Tan (@amanda-tan)
 - Guillaume Eynard-Bontemps (@guillaumeeb)
+- Chelle Gentemann (@cgentemann)


### PR DESCRIPTION
I'm please to announce that we are adding @cgentemann to the Pangeo Project's Steering Council. Chelle is a Senior Scientist at the Earth & Space Research Institute and the Farallon Institute. She has been an active advocate for inclusivity in STEM, open science, open source software, and the Pangeo Project. She is also uniquely positioned within the Earth Observation data systems community (e.g. NASA) and offers the Pangeo Project a view into how organizations will work to adopt emerging data science tools like Pangeo.

Please join me in welcoming Chelle to the council!

