### PR TITLE
Propose annual Steering Council meetings

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -137,7 +137,7 @@ they were active in the Council.
 #### Expectations for Council Members
 
 Steering council members are expected to commit to the following activities:
-- Attend a one-hour steering council meeting every quarter.
+- Attend a one-hour steering council meeting each fall.
 - Respond in a timely manner to steering-council-related correspondence.
 - Act as an ambassador for the project in professional contexts.
 - Contribute to fulfilling the Project's obligations to its Fiscal Sponsor.


### PR DESCRIPTION
Given that Pangeo has grown in its geographic diversity and the SC represents (I think) the full range of time zones, I'd like to propose that we update the synchronous meeting schedule to annually and develop mechanisms for more asynchronous communication between the SC. We could always meet on an as-needed basis in between the required annual meetings.